### PR TITLE
Update GBA loader + proc.py for IDA Pro 9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Copy to the installation directory of your IDA.
 
 ## Note
 - The directory 'fe' is for fire emblem exclusively, others work for all gba games.
-- [GBA loader](https://github.com/laqieer/ida_gba_stuff/blob/master/loaders/GBA_Loader.py) is updated to IDA 7.7, others are for IDA 7.0.
-- [GBA loader for IDA 9.0](https://github.com/vineberry/ida_gba_stuff-9.0/blob/master/loaders/GBA_Loader.py) thanks to @vineberry.
+- [GBA loader](https://github.com/laqieer/ida_gba_stuff/blob/master/loaders/GBA_Loader.py) is updated for **IDA 9.3** and works in both the GUI and headless [idalib](https://hex-rays.com/blog/ida-pro-9-0-idalib). The `.idc` scripts still run on IDA 7.0–9.x through IDA's `idc.idc` compatibility layer; `fe/scripts/proc.py` is fixed for IDA 9.x (`MakeFunction` → `add_func`).
+- The IDA 9.x port replaces the removed Python `idaapi.cvar.inf` writes with the `ida_ida.inf_set_start_ea/ip` setters (the old form is `None` under idalib). An earlier [GBA loader for IDA 9.0](https://github.com/vineberry/ida_gba_stuff-9.0/blob/master/loaders/GBA_Loader.py) by @vineberry exists too.

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Copy to the installation directory of your IDA.
 
 ## Note
 - The directory 'fe' is for fire emblem exclusively, others work for all gba games.
-- [GBA loader](https://github.com/laqieer/ida_gba_stuff/blob/master/loaders/GBA_Loader.py) is updated for **IDA 9.3** and works in both the GUI and headless [idalib](https://hex-rays.com/blog/ida-pro-9-0-idalib). The `.idc` scripts still run on IDA 7.0–9.x through IDA's `idc.idc` compatibility layer; `fe/scripts/proc.py` is fixed for IDA 9.x (`MakeFunction` → `add_func`).
+- [GBA loader](https://github.com/laqieer/ida_gba_stuff/blob/master/loaders/GBA_Loader.py) is updated for **IDA 9.3** and works in both the GUI and headless [idalib](https://hex-rays.com/blog/ida-pro-9-0-idalib). The `.idc` scripts still run on IDA 7.0–9.x through IDA's `idc.idc` compatibility layer; `fe/scripts/proc.py` is fixed for IDA 9.x / Python 3 (Python-2 `print` statements, integer division, and the removed `MakeFunction`/`find_binary`/`GetString` → `add_func`/`find_bytes`/`get_strlit_contents`).
 - The IDA 9.x port replaces the removed Python `idaapi.cvar.inf` writes with the `ida_ida.inf_set_start_ea/ip` setters (the old form is `None` under idalib). An earlier [GBA loader for IDA 9.0](https://github.com/vineberry/ida_gba_stuff-9.0/blob/master/loaders/GBA_Loader.py) by @vineberry exists too.

--- a/fe/scripts/proc.py
+++ b/fe/scripts/proc.py
@@ -95,7 +95,7 @@ def make_all_functions_in_proc(ea):
     Make all functions in a proc
     """
     for func in get_all_functions_in_proc(ea):
-        MakeFunction(func)
+        add_func(func)   # IDA 9.x: idc.MakeFunction was removed; use add_func
         
 def make_all_functions_in_all_procs():
     """

--- a/fe/scripts/proc.py
+++ b/fe/scripts/proc.py
@@ -54,12 +54,13 @@ def show_procs_info():
     Show the total num and range of procs in the game
     """
     proc_list = get_all_procs()
-    print "%d procs in total: from 0x%X to 0x%X" % (len(proc_list), min(proc_list), max(proc_list))
+    print("%d procs in total: from 0x%X to 0x%X" % (len(proc_list), min(proc_list), max(proc_list)))
 def get_end_addr(ea):
     """
     Get end address of a proc
     """
-    return find_binary(ea, SEARCH_DOWN, "00 00 00 00 00 00 00 00")
+    # IDA 9.x: idc.find_binary was removed; find_bytes takes (pattern, start_ea).
+    return find_bytes("00 00 00 00 00 00 00 00", ea)
 
 def make_proc(ea):
     """
@@ -67,7 +68,7 @@ def make_proc(ea):
     """
     create_struct(ea, 8, "proc")
     end = get_end_addr(ea)
-    make_array(ea, (end - ea) / 8 + 1)
+    make_array(ea, (end - ea) // 8 + 1)   # // : integer count for make_array (Python 3)
 
 def make_all_procs():
     """
@@ -109,7 +110,10 @@ def name_proc(ea):
     Name a proc
     """
     if get_dword(ea) == 1:
-        set_name(ea, "proc_%s" % GetString(get_dword(ea+4)))
+        # IDA 9.x: idc.GetString was removed; get_strlit_contents returns bytes.
+        name = get_strlit_contents(get_dword(ea + 4))
+        if name is not None:
+            set_name(ea, "proc_%s" % name.decode("ascii", "replace"))
 
 def name_all_procs(ea):
     """
@@ -120,7 +124,7 @@ def name_all_procs(ea):
 
 def main():
     procs = get_all_procs()
-    print "%d procs in total: from 0x%X to 0x%X" % (len(procs), min(procs), max(procs))
+    print("%d procs in total: from 0x%X to 0x%X" % (len(procs), min(procs), max(procs)))
     for proc in procs:
         name_proc(proc)
         make_proc(proc)

--- a/loaders/GBA_Loader.py
+++ b/loaders/GBA_Loader.py
@@ -4,6 +4,7 @@ Thank's to SiD3W4y/GhidraGBA and LIJI32/gameboy.py
 @thorodin-roth
 
 Ported to IDA 7.7 by laqieer
+Updated for IDA 9.3 by laqieer (works in both the GUI and headless idalib)
 '''
 
 import idaapi
@@ -13,6 +14,8 @@ import struct
 import ida_funcs
 import ida_bytes
 import ida_lines
+import ida_ida
+import ida_kernwin
 
 ROM_SIGNATURE_OFFSET = 0xb2
 ROM_SIGNATURE        = b"\x96"
@@ -66,7 +69,7 @@ def add_seg(startea, size, name,bitness=0,seg_cls="CONST",base=0,patch_bytes=Non
     
 def load_file(li, neflags, format):
     if format != RomFormatName:
-        Warning("Unkown format name: '%s'" % format)
+        ida_kernwin.warning("Unknown format name: '%s'" % format)
         return 0
 
     size = li.size()
@@ -87,8 +90,11 @@ def load_file(li, neflags, format):
         li.file2base(0, entry_form_ea, entry_to_ea, 1)
         ida_funcs.add_func(entry_form_ea)
         idaapi.add_entry(EntryPoint, EntryPoint, "start", 1)
-        idaapi.cvar.inf.startIP = EntryPoint
-        idaapi.cvar.inf.beginEA = EntryPoint
+        # IDA 9.x: the `idaapi.cvar.inf` struct is no longer writable like this
+        # (and is None under headless idalib). Use the inf_* setters, which work
+        # in both the GUI and idalib.
+        ida_ida.inf_set_start_ea(EntryPoint)
+        ida_ida.inf_set_start_ip(EntryPoint)
 
         ida_lines.add_extra_cmt(ROM_START, True, "ROM HEADER")
 


### PR DESCRIPTION
Makes the repo work on **IDA Pro 9.3** (the loader previously broke on 9.x).

## Real breakages (Python only)
- **`loaders/GBA_Loader.py`** — the namesake loader:
  - `idaapi.cvar.inf.startIP/beginEA = …` → `ida_ida.inf_set_start_ip/start_ea(…)`. In IDA 9.x `idaapi.cvar.inf` is no longer writable like this and is **`None` under headless idalib**, so the old form raised `'NoneType' object has no attribute 'startIP'`. The setters work in both the GUI and idalib.
  - `Warning(…)` → `ida_kernwin.warning(…)`. The old IDC `Warning` global is gone from the Python namespace; a bare `Warning(…)` now resolves to Python's built-in exception class and silently no-ops.
- **`fe/scripts/proc.py`** — `MakeFunction(func)` → `add_func(func)` (`MakeFunction` was removed from the Python `idc` module).

## Left unchanged on purpose
The `.idc` scripts (`idc/*.idc`, `plugins/*.idc`) still run on IDA 9.3 through IDA's `idc.idc` backward-compatibility aliases (`Byte`, `MakeName`, `Message`, `MakeFunction`, … are all still defined in `<ida>/idc/idc.idc`), so they need no changes.

## Verified
Loaded a GBA ROM headlessly with **idalib on IDA 9.3**: processor set to ARM, all 8 segments (BIOS/WRAM/IRAM/IO/OBJ/VRAM/OAM/ROM) created, entry `start` named, `open_database` returns OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)